### PR TITLE
Earlier fridges and with no microelectronics required

### DIFF
--- a/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Storage_WallFridge.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Storage_WallFridge.xml
@@ -30,7 +30,7 @@
 			<Rubber>15</Rubber>
 			<Plastic>10</Plastic>
 			<ComponentIndustrial>5</ComponentIndustrial>
-			<Electronics>2</Electronics>
+			<ElectronicComponents>3</ElectronicComponents>
 		</costList>
 		<statBases>
 			<Mass>15</Mass>
@@ -84,7 +84,7 @@
 			<Rubber>25</Rubber>
 			<Plastic>20</Plastic>
 			<ComponentIndustrial>10</ComponentIndustrial>
-			<Electronics>3</Electronics>
+			<ElectronicComponents>5</ElectronicComponents>
 		</costList>
 		<statBases>
 			<Mass>30</Mass>


### PR DESCRIPTION
Refrigerators should be available much earlier in the games progression. I dont see much sense in this, because we can easy & early build up our walk-in fridges but not small fridges. Refrigeratros also should not use higher tec components like microelectronics. They are also only available about late industrial stage, and up then you already have you big walk-in fridge that cost only some basic resources.